### PR TITLE
[hooks] Implement wrapper for readdir and readdir_r

### DIFF
--- a/libhybris/hybris/common/hooks.c
+++ b/libhybris/hybris/common/hooks.c
@@ -1176,6 +1176,79 @@ static int my_setlinebuf(FILE *fp)
     return 0;
 }
 
+/* "struct dirent" from bionic/libc/include/dirent.h */
+struct bionic_dirent {
+    uint64_t         d_ino;
+    int64_t          d_off;
+    unsigned short   d_reclen;
+    unsigned char    d_type;
+    char             d_name[256];
+};
+
+static struct bionic_dirent *my_readdir(DIR *dirp)
+{
+    /**
+     * readdir(3) manpage says:
+     *  The data returned by readdir() may be overwritten by subsequent calls
+     *  to readdir() for the same directory stream.
+     *
+     * XXX: At the moment, for us, the data will be overwritten even by
+     * subsequent calls to /different/ directory streams. Eventually fix that
+     * (e.g. by storing per-DIR * bionic_dirent structs, and removing them on
+     * closedir, requires hooking of all funcs returning/taking DIR *) and
+     * handling the additional data attachment there)
+     **/
+
+    static struct bionic_dirent result;
+
+    struct dirent *real_result = readdir(dirp);
+    if (!real_result) {
+        return NULL;
+    }
+
+    result.d_ino = real_result->d_ino;
+    result.d_off = real_result->d_off;
+    result.d_reclen = real_result->d_reclen;
+    result.d_type = real_result->d_type;
+    memcpy(result.d_name, real_result->d_name, sizeof(result.d_name));
+
+    // Make sure the string is zero-terminated, even if cut off (which
+    // shouldn't happen, as both bionic and glibc have d_name defined
+    // as fixed array of 256 chars)
+    result.d_name[sizeof(result.d_name)-1] = '\0';
+    return &result;
+}
+
+static int my_readdir_r(DIR *dir, struct bionic_dirent *entry,
+        struct bionic_dirent **result)
+{
+    struct dirent entry_r;
+    struct dirent *result_r;
+
+    int res = readdir_r(dir, &entry_r, &result_r);
+
+    if (res == 0) {
+        if (result_r != NULL) {
+            *result = entry;
+
+            entry->d_ino = entry_r.d_ino;
+            entry->d_off = entry_r.d_off;
+            entry->d_reclen = entry_r.d_reclen;
+            entry->d_type = entry_r.d_type;
+            memcpy(entry->d_name, entry_r.d_name, sizeof(entry->d_name));
+
+            // Make sure the string is zero-terminated, even if cut off (which
+            // shouldn't happen, as both bionic and glibc have d_name defined
+            // as fixed array of 256 chars)
+            entry->d_name[sizeof(entry->d_name) - 1] = '\0';
+        } else {
+            *result = NULL;
+        }
+    }
+
+    return res;
+}
+
 extern long my_sysconf(int name);
 
 FP_ATTRIB static double my_strtod(const char *nptr, char **endptr)
@@ -1258,7 +1331,15 @@ static struct _hook hooks[] = {
     {"strncasecmp",strncasecmp},
     /* dirent.h */
     {"opendir", opendir},
+    {"fdopendir", fdopendir},
     {"closedir", closedir},
+    {"readdir", my_readdir},
+    {"readdir_r", my_readdir_r},
+    {"rewinddir", rewinddir},
+    {"seekdir", seekdir},
+    {"telldir", telldir},
+    {"dirfd", dirfd},
+    // TODO: scandir, scandirat, alphasort, versionsort
     /* pthread.h */
     {"pthread_atfork", pthread_atfork},
     {"pthread_create", my_pthread_create},


### PR DESCRIPTION
struct dirent differs between bionic and glibc, and rewinddir needs
hooking.

Signed-off-by: Thomas Perl thomas.perl@jolla.com
