### PR TITLE
Use PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP in dlfcn.c

### DIFF
--- a/libhybris/hybris/common/jb/Makefile.am
+++ b/libhybris/hybris/common/jb/Makefile.am
@@ -18,6 +18,7 @@ libandroid_linker_la_CFLAGS = \
 	-I$(top_srcdir)/include \
 	$(ANDROID_HEADERS_CFLAGS) \
 	-I$(top_srcdir)/common \
+	-D_GNU_SOURCE \
 	-DLINKER_TEXT_BASE=0xB0000100 \
 	-DLINKER_AREA_SIZE=0x01000000 \
 	-DDEFAULT_HYBRIS_LD_LIBRARY_PATH="\"@DEFAULT_HYBRIS_LD_LIBRARY_PATH@\"" \

--- a/libhybris/hybris/common/jb/dlfcn.c
+++ b/libhybris/hybris/common/jb/dlfcn.c
@@ -43,7 +43,7 @@ static const char *dl_errors[] = {
 #define likely(expr)   __builtin_expect (expr, 1)
 #define unlikely(expr) __builtin_expect (expr, 0)
 
-static pthread_mutex_t dl_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t dl_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
 static void set_dlerror(int err)
 {


### PR DESCRIPTION
Needed by certain android bsp.

This is basically a cherry-pick from android upstream. The original code
is available as part of the bionic commit e19d702.

Change-Id: I090fbc06fc9453a3419eb9ec05b0cd932d17c971
Signed-off-by: Yuan-Chen Cheng yc.cheng@canonical.com
Signed-off-by: Ricardo Salveti de Araujo rsalveti@rsalveti.net
