### PR TITLE
Re-Revert "Fix calling gl* functions without loading them with eglGet…

### DIFF
--- a/libhybris/hybris/glesv2/glesv2.c
+++ b/libhybris/hybris/glesv2/glesv2.c
@@ -60,8 +60,6 @@ This generates a function that when first called overwrites it's plt entry with 
 typeof(sym) * sym ## _dispatch (void) __asm__ (#sym);\
 typeof(sym) * sym ## _dispatch (void) \
 { \
-	if (!_libglesv2) \
-		_libglesv2 = (void *) android_dlopen(getenv("LIBGLESV2") ? getenv("LIBGLESV2") : "libGLESv2.so", RTLD_NOW); \
 	return (void *) android_dlsym(_libglesv2, #sym); \
 } 
 


### PR DESCRIPTION
…ProcAddress"

The change was reintroduced by mistake in 89a94989b56789793bc3ea7636f2cae1b211bcc6