### PR TITLE
Look for libhardware.so from default search path 

### DIFF
--- a/libhybris/hybris/hardware/hardware.c
+++ b/libhybris/hybris/hardware/hardware.c
@@ -31,7 +31,7 @@ static int (*_hw_get_module_by_class)(const char *class_id, const char *inst, co
 
 static void _init_lib_hardware()
 {
-	_libhardware = (void *) android_dlopen("/system/lib/libhardware.so", RTLD_LAZY);
+	_libhardware = (void *) android_dlopen("libhardware.so", RTLD_LAZY);
 }
 
 int hw_get_module(const char *id, const struct hw_module_t **module)


### PR DESCRIPTION
Look for libhardware.so from default search path instead of hardcoding the path so we can use a patched version of libhardware.so from /usr/libexec/droid-hybris/system/lib/.