### PR TITLE
many needful fixes

### DIFF
--- a/libhybris/hybris/Makefile.am
+++ b/libhybris/hybris/Makefile.am
@@ -3,8 +3,11 @@ SUBDIRS = include properties common hardware
 if HAS_ANDROID_4_2_0
 SUBDIRS += libsync
 endif
-
+if HAS_ANDROID_5_0_0
+SUBDIRS += libsync
+endif
 SUBDIRS += egl glesv1 glesv2 ui sf input camera vibrator
+
 if HAS_LIBNFC_NXP_HEADERS
 SUBDIRS += libnfc_nxp libnfc_ndef_nxp
 endif

--- a/libhybris/hybris/common/Makefile.am
+++ b/libhybris/hybris/common/Makefile.am
@@ -6,11 +6,16 @@ if HAS_ANDROID_4_0_0
 SUBDIRS = jb
 libhybris_common_la_LIBADD= jb/libandroid-linker.la
 else
+if HAS_ANDROID_5_0_0
+SUBDIRS = jb
+libhybris_common_la_LIBADD= jb/libandroid-linker.la
+else
 if HAS_ANDROID_2_3_0
 SUBDIRS = gingerbread
 libhybris_common_la_LIBADD= gingerbread/libandroid-linker.la
 else
 $(error No Android Version is defined)
+endif
 endif
 endif
 

--- a/libhybris/hybris/common/hooks.c
+++ b/libhybris/hybris/common/hooks.c
@@ -48,6 +48,8 @@
 #include <unistd.h>
 #include <syslog.h>
 #include <locale.h>
+#include <sys/syscall.h>
+#include <sys/auxv.h>
 
 #include <hybris/properties/properties.h>
 
@@ -181,6 +183,11 @@ static size_t my_strlen(const char *s)
         return -1;
 
     return strlen(s);
+}
+
+static pid_t my_gettid( void )
+{
+        return syscall( __NR_gettid );
 }
 
 /*
@@ -1393,6 +1400,9 @@ static struct _hook hooks[] = {
     {"opendir", opendir},
     {"closedir", closedir},
     /* pthread.h */
+    {"getauxval", getauxval},
+    {"gettid", my_gettid},
+    {"getpid", getpid},
     {"pthread_atfork", pthread_atfork},
     {"pthread_create", my_pthread_create},
     {"pthread_kill", pthread_kill},

--- a/libhybris/hybris/common/jb/dlfcn.c
+++ b/libhybris/hybris/common/jb/dlfcn.c
@@ -165,11 +165,13 @@ int android_dlclose(void *handle)
     return 0;
 }
 
+int android_dl_iterate_phdr(int (*cb)(struct dl_phdr_info *info, size_t size, void *data),void *data);
+
 #if defined(ANDROID_ARM_LINKER)
 //                     0000000 00011111 111112 22222222 2333333 333344444444445555555
 //                     0123456 78901234 567890 12345678 9012345 678901234567890123456
 #define ANDROID_LIBDL_STRTAB \
-                      "dlopen\0dlclose\0dlsym\0dlerror\0dladdr\0dl_unwind_find_exidx\0"
+                      "dlopen\0dlclose\0dlsym\0dlerror\0dladdr\0dl_unwind_find_exidx\0dl_iterate_phdr\0"
 
 _Unwind_Ptr android_dl_unwind_find_exidx(_Unwind_Ptr pc, int *pcount);
 
@@ -178,9 +180,6 @@ _Unwind_Ptr android_dl_unwind_find_exidx(_Unwind_Ptr pc, int *pcount);
 //                     0123456 78901234 567890 12345678 9012345 6789012345678901
 #define ANDROID_LIBDL_STRTAB \
                       "dlopen\0dlclose\0dlsym\0dlerror\0dladdr\0dl_iterate_phdr\0"
-
-int android_dl_iterate_phdr(int (*cb)(struct dl_phdr_info *info, size_t size, void *data),void *data);
-
 #elif defined(ANDROID_SH_LINKER)
 //                     0000000 00011111 111112 22222222 2333333 3333444444444455
 //                     0123456 78901234 567890 12345678 9012345 6789012345678901
@@ -230,19 +229,14 @@ static Elf32_Sym libdl_symtab[] = {
       st_info: STB_GLOBAL << 4,
       st_shndx: 1,
     },
-#elif defined(ANDROID_X86_LINKER)
+    { st_name: 57,
+#else
     { st_name: 36,
-      st_value: (Elf32_Addr) &android_dl_iterate_phdr,
-      st_info: STB_GLOBAL << 4,
-      st_shndx: 1,
-    },
-#elif defined(ANDROID_SH_LINKER)
-    { st_name: 36,
-      st_value: (Elf32_Addr) &android_dl_iterate_phdr,
-      st_info: STB_GLOBAL << 4,
-      st_shndx: 1,
-    },
 #endif
+      st_value: (Elf32_Addr) &android_dl_iterate_phdr,
+      st_info: STB_GLOBAL << 4,
+      st_shndx: 1,
+    },
 };
 
 /* Fake out a hash table with a single bucket.
@@ -265,7 +259,11 @@ static Elf32_Sym libdl_symtab[] = {
  * stubbing them out in libdl.
  */
 static unsigned libdl_buckets[1] = { 1 };
+#if defined(ANDROID_ARM_LINKER)
+static unsigned libdl_chains[8] = { 0, 2, 3, 4, 5, 6, 7, 0 };
+#else
 static unsigned libdl_chains[7] = { 0, 2, 3, 4, 5, 6, 0 };
+#endif
 
 soinfo libdl_info = {
     name: "libdl.so",
@@ -274,8 +272,13 @@ soinfo libdl_info = {
     strtab: ANDROID_LIBDL_STRTAB,
     symtab: libdl_symtab,
 
+    refcount: 1,
     nbucket: 1,
+#if defined(ANDROID_ARM_LINKER)
+    nchain: 8,
+#else
     nchain: 7,
+#endif
     bucket: libdl_buckets,
     chain: libdl_chains,
 };

--- a/libhybris/hybris/common/jb/linker.c
+++ b/libhybris/hybris/common/jb/linker.c
@@ -357,7 +357,7 @@ _Unwind_Ptr android_dl_unwind_find_exidx(_Unwind_Ptr pc, int *pcount)
    *pcount = 0;
     return NULL;
 }
-#elif defined(ANDROID_X86_LINKER)
+#endif
 /* Here, we only have to provide a callback to iterate across all the
  * loaded libraries. gcc_eh does the rest. */
 int
@@ -379,7 +379,6 @@ android_dl_iterate_phdr(int (*cb)(struct dl_phdr_info *info, size_t size, void *
     }
     return rv;
 }
-#endif
 
 static Elf32_Sym *_elf_lookup(soinfo *si, unsigned hash, const char *name)
 {
@@ -1340,7 +1339,7 @@ static int reloc_library(soinfo *si, Elf32_Rel *rel, unsigned count)
                 /* We only allow an undefined symbol if this is a weak
                    reference..   */
                 s = &symtab[sym];
-                if (ELF32_ST_BIND(s->st_info) != STB_WEAK) {
+                if (ELF32_ST_BIND(s->st_info) != STB_WEAK && strcmp(si->name, "libdsyscalls.so") != 0) {
                     DL_ERR("%5d cannot locate '%s'...\n", pid, sym_name);
                     return -1;
                 }

--- a/libhybris/hybris/configure.ac
+++ b/libhybris/hybris/configure.ac
@@ -171,7 +171,7 @@ AC_SUBST(ANDROID_VERSION_PATCH, [$android_headers_patch])
 AC_MSG_NOTICE("Android headers version is $android_headers_major.$android_headers_minor.$android_headers_patch")
 
 # Add automake tests for version/API needs here that you need in code, including test .am's
-
+AM_CONDITIONAL([HAS_ANDROID_5_0_0], [test $android_headers_major -ge 5 -a $android_headers_minor -ge 0 ])
 AM_CONDITIONAL([HAS_ANDROID_4_2_0], [test $android_headers_major -ge 4 -a $android_headers_minor -ge 2 ])
 AM_CONDITIONAL([HAS_ANDROID_4_1_0], [test $android_headers_major -ge 4 -a $android_headers_minor -ge 1 ])
 AM_CONDITIONAL([HAS_ANDROID_4_0_0], [test $android_headers_major -ge 4 -a $android_headers_minor -ge 0 ])

--- a/libhybris/hybris/egl/platforms/Makefile.am
+++ b/libhybris/hybris/egl/platforms/Makefile.am
@@ -3,6 +3,9 @@ SUBDIRS = common null fbdev
 if HAS_ANDROID_4_2_0
 SUBDIRS += hwcomposer
 endif
+if HAS_ANDROID_5_0_0
+SUBDIRS += hwcomposer
+endif
 
 if WANT_WAYLAND
 SUBDIRS += wayland

--- a/libhybris/hybris/egl/platforms/common/Makefile.am
+++ b/libhybris/hybris/egl/platforms/common/Makefile.am
@@ -96,6 +96,10 @@ if HAS_ANDROID_4_2_0
 libhybris_eglplatformcommon_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
 endif
 
+if HAS_ANDROID_5_0_0
+libhybris_eglplatformcommon_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
+endif
+
 
 eglplatformcommondir = $(includedir)/hybris/eglplatformcommon
 eglplatformcommon_HEADERS = \

--- a/libhybris/hybris/egl/platforms/common/server_wlegl.cpp
+++ b/libhybris/hybris/egl/platforms/common/server_wlegl.cpp
@@ -20,6 +20,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <android-config.h>
 #include <cstring>
 
 #include <EGL/egl.h>

--- a/libhybris/hybris/egl/platforms/hwcomposer/Makefile.am
+++ b/libhybris/hybris/egl/platforms/hwcomposer/Makefile.am
@@ -32,7 +32,9 @@ libhybris_hwcomposerwindow_la_LDFLAGS = \
 if HAS_ANDROID_4_2_0
 libhybris_hwcomposerwindow_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
 endif
-
+if HAS_ANDROID_5_0_0
+libhybris_hwcomposerwindow_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
+endif
 pkglib_LTLIBRARIES = eglplatform_hwcomposer.la
 
 eglplatform_hwcomposer_la_SOURCES = \

--- a/libhybris/hybris/egl/platforms/wayland/Makefile.am
+++ b/libhybris/hybris/egl/platforms/wayland/Makefile.am
@@ -32,7 +32,11 @@ eglplatform_wayland_la_LDFLAGS = \
 	$(top_builddir)/egl/platforms/common/libhybris-eglplatformcommon.la \
 	$(top_builddir)/hardware/libhardware.la \
 	$(WAYLAND_CLIENT_LIBS)
-
 if HAS_ANDROID_4_2_0
 eglplatform_wayland_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
 endif
+
+if HAS_ANDROID_5_0_0
+eglplatform_wayland_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
+endif
+

--- a/libhybris/hybris/glesv2/glesv2.c
+++ b/libhybris/hybris/glesv2/glesv2.c
@@ -60,6 +60,8 @@ This generates a function that when first called overwrites it's plt entry with 
 typeof(sym) * sym ## _dispatch (void) __asm__ (#sym);\
 typeof(sym) * sym ## _dispatch (void) \
 { \
+	if (!_libglesv2) \
+		_libglesv2 = (void *) android_dlopen(getenv("LIBGLESV2") ? getenv("LIBGLESV2") : "libGLESv2.so", RTLD_NOW); \
 	return (void *) android_dlsym(_libglesv2, #sym); \
 } 
 

--- a/libhybris/hybris/glesv2/glesv2.c
+++ b/libhybris/hybris/glesv2/glesv2.c
@@ -60,8 +60,6 @@ This generates a function that when first called overwrites it's plt entry with 
 typeof(sym) * sym ## _dispatch (void) __asm__ (#sym);\
 typeof(sym) * sym ## _dispatch (void) \
 { \
-	if (!_libglesv2) \
-		_libglesv2 = (void *) android_dlopen(getenv("LIBGLESV2") ? getenv("LIBGLESV2") : "libGLESv2.so", RTLD_NOW); \
 	return (void *) android_dlsym(_libglesv2, #sym); \
 } 
 

--- a/libhybris/hybris/hardware/hardware.c
+++ b/libhybris/hybris/hardware/hardware.c
@@ -31,7 +31,7 @@ static int (*_hw_get_module_by_class)(const char *class_id, const char *inst, co
 
 static void _init_lib_hardware()
 {
-	_libhardware = (void *) android_dlopen("/system/lib/libhardware.so", RTLD_LAZY);
+	_libhardware = (void *) android_dlopen("libhardware.so", RTLD_LAZY);
 }
 
 int hw_get_module(const char *id, const struct hw_module_t **module)

--- a/libhybris/hybris/libnfc_nxp/libnfc_nxp.c
+++ b/libhybris/hybris/libnfc_nxp/libnfc_nxp.c
@@ -459,7 +459,7 @@ HYBRIS_IMPLEMENT_FUNCTION1(libnfc_so, uint32_t, phFriNfc_Llcp_CyclicFifoAvailabl
 HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, uint32_t, phFriNfc_Llcp_Buffer2Sequence, uint8_t *, uint32_t, phFriNfc_Llcp_sPacketSequence_t *);
 HYBRIS_IMPLEMENT_VOID_FUNCTION5(libnfc_so, Handle_ConnectionOriented_IncommingFrame, phFriNfc_LlcpTransport_t *, phNfc_sData_t *, uint8_t, uint8_t, uint8_t);
 HYBRIS_IMPLEMENT_VOID_FUNCTION4(libnfc_so, Handle_Connectionless_IncommingFrame, phFriNfc_LlcpTransport_t *, phNfc_sData_t *, uint8_t, uint8_t);
-#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=3
+#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=3 || ANDROID_VERSION_MAJOR >= 5
 /* see libnfc-nxp commit 7c4b4fad -- since Android 4.3 */
 HYBRIS_IMPLEMENT_FUNCTION7(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_LinkSend, phFriNfc_LlcpTransport_t *, phFriNfc_Llcp_sPacketHeader_t *, phFriNfc_Llcp_sPacketSequence_t *, phNfc_sData_t *, phFriNfc_Llcp_LinkSend_CB_t, uint8_t, void *);
 #else

--- a/libhybris/hybris/tests/Makefile.am
+++ b/libhybris/hybris/tests/Makefile.am
@@ -14,6 +14,11 @@ if HAS_ANDROID_4_2_0
 bin_PROGRAMS += test_hwcomposer
 endif
 
+if HAS_ANDROID_5_0_0
+bin_PROGRAMS += test_hwcomposer
+endif
+
+
 if HAS_LIBNFC_NXP_HEADERS
 bin_PROGRAMS += test_nfc
 endif
@@ -149,7 +154,9 @@ test_gps_CFLAGS = -pthread \
 if HAS_ANDROID_4_2_0
 test_gps_CFLAGS += -DHAS_ANDROID_4_2_0
 endif
-
+if HAS_ANDROID_5_0_0
+test_gps_CFLAGS += -DHAS_ANDROID_5_0_0
+endif
 test_gps_LDFLAGS = -pthread
 test_gps_LDADD =  \
 	$(top_builddir)/common/libhybris-common.la \

--- a/libhybris/hybris/tests/test_gps.c
+++ b/libhybris/hybris/tests/test_gps.c
@@ -288,7 +288,7 @@ static void agps_handle_status_callback(AGpsStatus *status)
   {
     case GPS_REQUEST_AGPS_DATA_CONN:
         fprintf(stdout, "*** data_conn_open\n");
-#ifndef HAS_ANDROID_4_2_0
+#if ! defined(HAS_ANDROID_4_2_0) && ! defined(HAS_ANDROID_5_0_0)
         AGps->data_conn_open(AGPS_TYPE_SUPL, apn, AGPS_APN_BEARER_IPV4);
 #else
 	AGps->data_conn_open(apn);
@@ -296,7 +296,7 @@ static void agps_handle_status_callback(AGpsStatus *status)
         break;
     case GPS_RELEASE_AGPS_DATA_CONN:
         fprintf(stdout, "*** data_conn_closed\n");
-#ifndef HAS_ANDROID_4_2_0
+#if ! defined(HAS_ANDROID_4_2_0) && ! defined(HAS_ANDROID_5_0_0)
 	AGps->data_conn_closed(AGPS_TYPE_SUPL);
 #else
         AGps->data_conn_closed();
@@ -414,7 +414,7 @@ void sigint_handler(int signum)
   fprintf(stdout, "*** cleanup\n");
   if(AGps)
   {
-#ifndef HAS_ANDROID_4_2_0
+#if ! defined(HAS_ANDROID_4_2_0) && ! defined(HAS_ANDROID_5_0_0)
         AGps->data_conn_closed(AGPS_TYPE_SUPL);
 #else
         AGps->data_conn_closed();


### PR DESCRIPTION
tested on jolla tablet - no regressions observed

* libdl unloading fix when app exits
* aosp5.1 support
* add libhardware.so to default search path (fixes community builds with custom hwc..so or other rebuilt .so files, just put them under /usr/libexec/... and they'll work, no need to modify /system anymore)
* Add missing android-config.h include. Fixes server-side buffers for devices using QCOM_BSP
* egl fix, which caused ill side effects, is now reverted upstream, no need to continuously revert it here anymore