### PR TITLE
hybris: hook glibc_malloc to malloc

### DIFF
--- a/libhybris/hybris/common/hooks.c
+++ b/libhybris/hybris/common/hooks.c
@@ -2592,13 +2592,6 @@ static struct _hook hooks_common[] = {
     HOOK_INDIRECT(dlsym),
     HOOK_INDIRECT(dladdr),
     HOOK_INDIRECT(dlclose),
-    HOOK_DIRECT_NO_DEBUG(malloc),
-    HOOK_DIRECT_NO_DEBUG(free),
-    HOOK_DIRECT_NO_DEBUG(calloc),
-    HOOK_DIRECT_NO_DEBUG(realloc),
-    HOOK_DIRECT_NO_DEBUG(valloc),
-    HOOK_DIRECT_NO_DEBUG(pvalloc),
-    HOOK_DIRECT_NO_DEBUG(malloc_usable_size),
 #else
     HOOK_DIRECT(property_get),
     HOOK_DIRECT(property_set),

--- a/libhybris/hybris/common/hooks.c
+++ b/libhybris/hybris/common/hooks.c
@@ -2491,6 +2491,7 @@ static int _hybris_hook_my_printf(const char *tmp, ...)
 
 static struct _hook hooks_common[] = {
 #ifdef WANT_INITIALIZE_BIONIC
+    HOOK_TO(glibc_malloc, malloc),
     HOOK_INDIRECT(my_printf),
     HOOK_DIRECT(property_get),
     HOOK_DIRECT(property_set),

--- a/libhybris/hybris/common/hooks.c
+++ b/libhybris/hybris/common/hooks.c
@@ -350,6 +350,9 @@ static int _hybris_hook_pthread_setspecific(pthread_key_t key, const void *ptr)
 {
     TRACE_HOOK("key %d ptr %" PRIdPTR, key, (intptr_t) ptr);
 
+    // see android_bionic/tests/pthread_test.cpp, test static_pthread_key_used_before_creation
+    if(!key) return EINVAL;
+
     return pthread_setspecific(key, ptr);
 }
 
@@ -361,6 +364,16 @@ static void* _hybris_hook_pthread_getspecific(pthread_key_t key)
     if(!key) return NULL;
 
     return pthread_getspecific(key);
+}
+
+static int _hybris_hook_pthread_key_delete(pthread_key_t key)
+{
+    TRACE_HOOK("key %d", key);
+
+    // see android_bionic/tests/pthread_test.cpp, test static_pthread_key_used_before_creation
+    if(!key) return EINVAL;
+
+    return pthread_key_delete(key);
 }
 
 /*
@@ -2501,6 +2514,8 @@ static struct _hook hooks_common[] = {
     HOOK_DIRECT_NO_DEBUG(clone),
     HOOK_TO(__errno, __errno_location),
 
+    HOOK_TO(__register_atfork, pthread_atfork),
+
     /* pthread.h */
     HOOK_DIRECT_NO_DEBUG(getauxval),
     HOOK_INDIRECT(gettid),
@@ -2543,11 +2558,11 @@ static struct _hook hooks_common[] = {
     HOOK_TO(pthread_cond_timedwait_monotonic, _hybris_hook_pthread_cond_timedwait),
     HOOK_TO(pthread_cond_timedwait_monotonic_np, _hybris_hook_pthread_cond_timedwait),
     HOOK_INDIRECT(pthread_cond_timedwait_relative_np),
-    HOOK_DIRECT_NO_DEBUG(pthread_key_delete),
+    HOOK_INDIRECT(pthread_key_delete),
     HOOK_INDIRECT(pthread_setname_np),
     HOOK_DIRECT_NO_DEBUG(pthread_once),
     HOOK_DIRECT_NO_DEBUG(pthread_key_create),
-    HOOK_DIRECT(pthread_setspecific),
+    HOOK_INDIRECT(pthread_setspecific),
     HOOK_INDIRECT(pthread_getspecific),
     HOOK_INDIRECT(pthread_attr_init),
     HOOK_INDIRECT(pthread_attr_destroy),
@@ -2699,11 +2714,11 @@ static struct _hook hooks_common[] = {
     HOOK_TO(pthread_cond_timedwait_monotonic, _hybris_hook_pthread_cond_timedwait),
     HOOK_TO(pthread_cond_timedwait_monotonic_np, _hybris_hook_pthread_cond_timedwait),
     HOOK_INDIRECT(pthread_cond_timedwait_relative_np),
-    HOOK_DIRECT_NO_DEBUG(pthread_key_delete),
+    HOOK_INDIRECT(pthread_key_delete),
     HOOK_INDIRECT(pthread_setname_np),
     HOOK_DIRECT_NO_DEBUG(pthread_once),
     HOOK_DIRECT_NO_DEBUG(pthread_key_create),
-    HOOK_DIRECT(pthread_setspecific),
+    HOOK_INDIRECT(pthread_setspecific),
     HOOK_INDIRECT(pthread_getspecific),
     HOOK_INDIRECT(pthread_attr_init),
     HOOK_INDIRECT(pthread_attr_destroy),

--- a/libhybris/hybris/common/hooks.c
+++ b/libhybris/hybris/common/hooks.c
@@ -2592,6 +2592,13 @@ static struct _hook hooks_common[] = {
     HOOK_INDIRECT(dlsym),
     HOOK_INDIRECT(dladdr),
     HOOK_INDIRECT(dlclose),
+    HOOK_DIRECT_NO_DEBUG(malloc),
+    HOOK_DIRECT_NO_DEBUG(free),
+    HOOK_DIRECT_NO_DEBUG(calloc),
+    HOOK_DIRECT_NO_DEBUG(realloc),
+    HOOK_DIRECT_NO_DEBUG(valloc),
+    HOOK_DIRECT_NO_DEBUG(pvalloc),
+    HOOK_DIRECT_NO_DEBUG(malloc_usable_size),
 #else
     HOOK_DIRECT(property_get),
     HOOK_DIRECT(property_set),

--- a/libhybris/hybris/common/hooks.c
+++ b/libhybris/hybris/common/hooks.c
@@ -1983,34 +1983,6 @@ static long int _hybris_hook_strtol(const char* str, char** endptr, int base)
     return strtol(str, endptr, base);
 }
 
-char *_hybris_hook_getenv(const char *name)
-{
-    TRACE_HOOK("name '%s'", name);
-
-    return getenv(name);
-}
-
-int _hybris_hook_setenv(const char *name, const char *value, int overwrite)
-{
-    TRACE_HOOK("name '%s' value '%s' overwrite %d", name, value, overwrite);
-
-    return setenv(name, value, overwrite);
-}
-
-int _hybris_hook_putenv(char *string)
-{
-    TRACE_HOOK("string '%s'", string);
-
-    return putenv(string);
-}
-
-int _hybris_hook_clearenv(void)
-{
-    TRACE_HOOK("");
-
-    return clearenv();
-}
-
 extern int __cxa_atexit(void (*)(void*), void*, void*);
 extern void __cxa_finalize(void * d);
 
@@ -2477,6 +2449,34 @@ static pid_t _hybris_hook_gettid(void)
     return syscall(__NR_gettid);
 }
 
+char *_hybris_hook_getenv(const char *name)
+{
+    TRACE_HOOK("name '%s'", name);
+
+    return getenv(name);
+}
+
+int _hybris_hook_setenv(const char *name, const char *value, int overwrite)
+{
+    TRACE_HOOK("name '%s' value '%s' overwrite %d", name, value, overwrite);
+
+    return setenv(name, value, overwrite);
+}
+
+int _hybris_hook_putenv(char *string)
+{
+    TRACE_HOOK("string '%s'", string);
+
+    return putenv(string);
+}
+
+int _hybris_hook_clearenv(void)
+{
+    TRACE_HOOK("");
+
+    return clearenv();
+}
+
 // hook to print messages from bionic libc (in order to debug invalid pthread calls)
 // also useful for debugging
 static int _hybris_hook_my_printf(const char *tmp, ...)
@@ -2607,6 +2607,11 @@ static struct _hook hooks_common[] = {
     HOOK_INDIRECT(dlsym),
     HOOK_INDIRECT(dladdr),
     HOOK_INDIRECT(dlclose),
+
+    HOOK_DIRECT(getenv),
+    HOOK_DIRECT(setenv),
+    HOOK_DIRECT(putenv),
+    HOOK_DIRECT(clearenv),
 #else
     HOOK_DIRECT(property_get),
     HOOK_DIRECT(property_set),


### PR DESCRIPTION
glibc_malloc is a custom function which was added to bionic in order to be able to use glibc malloc inside bionic functions whenever they return a pointer to glibc environment. only useful for minimal hooks method

some devices break when hooking the glibc *alloc/free functions over the bionic *alloc/free functions
in order to avoid having to hook them but for droidmedia to still work properly this was added => droidmedia will
call glibc_malloc for the single pointer it returns to glibc space.

if the bionic patch is applied as well as the droidmedia patch which are required for minimal hooks but --enable-initialize-bionic
is not included this will still work since the default behaviour of glibc_malloc is to call malloc which will be hooked to glibc alloc
in the non-minimal hooks method