### PR TITLE
[hybris] implement adreno quriks

### DIFF
--- a/libhybris/hybris/common/Makefile.am
+++ b/libhybris/hybris/common/Makefile.am
@@ -27,6 +27,9 @@ libhybris_common_la_CPPFLAGS = \
 	$(ANDROID_HEADERS_CFLAGS) \
 	-I$(top_srcdir)/common \
 	-DLINKER_PLUGIN_DIR=\"$(libdir)/libhybris/linker\"
+if WANT_ADRENO_QUIRKS
+libhybris_common_la_CPPFLAGS += -DWANT_ADRENO_QUIRKS
+endif
 if WANT_TRACE
 libhybris_common_la_CPPFLAGS += -DDEBUG
 endif

--- a/libhybris/hybris/common/hooks.c
+++ b/libhybris/hybris/common/hooks.c
@@ -285,6 +285,10 @@ static void *_hybris_hook_malloc(size_t size)
 {
     TRACE_HOOK("size %zu", size);
 
+#ifdef WANT_ADRENO_QUIRKS
+    if(size == 4) size = 5;
+#endif
+
     void *res = malloc(size);
 
     TRACE_HOOK("res %p", res);
@@ -2430,7 +2434,7 @@ static struct _hook hooks_common[] = {
     HOOK_INDIRECT(__system_property_get),
     HOOK_DIRECT(getenv),
     HOOK_DIRECT_NO_DEBUG(printf),
-    HOOK_DIRECT(malloc),
+    HOOK_INDIRECT(malloc),
     HOOK_DIRECT_NO_DEBUG(free),
     HOOK_DIRECT_NO_DEBUG(calloc),
     HOOK_DIRECT_NO_DEBUG(cfree),

--- a/libhybris/hybris/configure.ac
+++ b/libhybris/hybris/configure.ac
@@ -48,6 +48,12 @@ AC_ARG_ENABLE(experimental,
   [experimental="no"])
 AM_CONDITIONAL( [WANT_EXPERIMENTAL], [test x"$experimental" = x"yes"])
 
+AC_ARG_ENABLE(adreno_quirks,
+  [  --enable-adreno-quirks     Enable adreno quirks (default=disabled)],
+  [adreno_quirks=$enableval],
+  [adreno_quirks="no"])
+AM_CONDITIONAL( [WANT_ADRENO_QUIRKS], [test x"$adreno_quirks" = x"yes"])
+
 AC_ARG_ENABLE(trace,
   [  --enable-trace            Enable TRACE statements (default=disabled)],
   [trace=$enableval],


### PR DESCRIPTION
When --enable-adreno-quirks is specified then treat malloc(4) as
if it was malloc(5) in order to avoid SIGSEGV and shader
compilation errors due to out-of-bounds accesses found within
common adreno EGL/GLES blobs.

These errors are usually found on 64 bit devices and this works
around this issue until a better solution is found.