### PR TITLE
hybris: common: n: dlerror shall return NULL on dlsym success

### DIFF
--- a/libhybris/hybris/common/n/dlfcn.cpp
+++ b/libhybris/hybris/common/n/dlfcn.cpp
@@ -34,8 +34,8 @@
 
 static pthread_mutex_t g_dl_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
-static char dl_err_buf[1024];
-//static const char *dl_err_str;
+static __thread const char *dl_err_str;
+char __thread dlerror_buffer[__BIONIC_DLERROR_BUFFER_SIZE];
 
 static const char* __bionic_set_dlerror(char* new_value) {
 #ifdef DISABLED_FOR_HYBRIS_SUPPORT
@@ -45,9 +45,8 @@ static const char* __bionic_set_dlerror(char* new_value) {
   *dlerror_slot = new_value;
   return old_value;
 #else
-  char *dlerror_slot = dl_err_buf;
-  const char *old_value = dlerror_slot;
-  dlerror_slot = new_value;
+  const char *old_value = dl_err_str;
+  dl_err_str = new_value;
   return old_value;
 #endif
 }
@@ -56,7 +55,7 @@ static void __bionic_format_dlerror(const char* msg, const char* detail) {
 #ifdef DISABLED_FOR_HYBRIS_SUPPORT
   char* buffer = __get_thread()->dlerror_buffer;
 #else
-  char* buffer = dl_err_buf;
+  char* buffer = dlerror_buffer;
 #endif
   strlcpy(buffer, msg, __BIONIC_DLERROR_BUFFER_SIZE);
   if (detail != nullptr) {


### PR DESCRIPTION
since some code depends on it

also use __thread to store the dlerror buffer since original bionic dlfcn.cpp also uses TLS.

Signed-off-by: Franz-Josef Haider <f_haider@gmx.at>