### PR TITLE
libhybris: Update submodule and adapt spec

### DIFF
--- a/rpm/libhybris.spec
+++ b/rpm/libhybris.spec
@@ -290,11 +290,6 @@ cd hybris
 %ifarch %{arm}
   %{?qa_stage_devel:--enable-arm-tracing} \
 %endif
-%if 0%{?android_headers:1}
-  --with-android-headers=%{android_headers} \
-%else
-  --with-android-headers=%{_libdir}/droid-devel/droid-headers \
-%endif
   --enable-property-cache \
 %ifarch %{arm}
   --enable-arch=arm \


### PR DESCRIPTION
[libhybris] egl: tests: Add libhardware to ld flags
[libhybris] hybris: Remove automatically generated INSTALL file. JB#38781
[libhybris] configure: Check android headers also when pkgconfig is used. JB#38781
[libhybris] eglplatform: Fix handling max buffer count. JB#51520
[libhybris] hybris: hook __cxa_thread_atexit
[libhybris] hybris: use internal counter for __cxa_thread_exit