### PR TITLE
libhybris: support Android 10, egl and aarch64 fixes (master edition)

### DIFF
--- a/rpm/libhybris.spec
+++ b/rpm/libhybris.spec
@@ -505,6 +505,7 @@ install -m0644 AUTHORS %{buildroot}%{_docdir}/%{name}-%{version}
 %files tests
 %defattr(-,root,root,-)
 %{_bindir}/test_audio
+%{_bindir}/test_dlopen
 %{_bindir}/test_egl
 %{_bindir}/test_egl_configs
 %{_bindir}/test_glesv2


### PR DESCRIPTION
Submodule delta contains new test for dlopen. Spec file updated.

[libhybris] support Android 10. Fixes JB#52324
[libhybris] egl: Set buffer dimensions on window resize. JB#52698
[libhybris] hybris: introduce ARM64 support for HYBRIS_TRACE_(DYNHOOKED/UNHOOKED/HOOKED)