### PR TITLE
libhybris: Update submodule.

### DIFF
--- a/rpm/libhybris.spec
+++ b/rpm/libhybris.spec
@@ -287,7 +287,7 @@ cd hybris
   --enable-wayland \
   %{?qa_stage_devel:--enable-debug} \
   %{?qa_stage_devel:--enable-trace} \
-%ifarch %{arm}
+%ifnarch %{ix86}
   %{?qa_stage_devel:--enable-arm-tracing} \
 %endif
   --enable-property-cache \


### PR DESCRIPTION
[libhybris] hybris: common: q: prioritize library path set by environment variable. JB#53238
[libhybris] hybris: hook close. JB#53238
[libhybris] hybris: fix wrappers for aarch64. JB#53238
[libhybris] hybris: support HYBRIS_TRACE_(*)HOOKED in q linker. JB#53238